### PR TITLE
Fix invalid string template exression

### DIFF
--- a/bot-integration-samples/hotel-finder/nodejs/app.js
+++ b/bot-integration-samples/hotel-finder/nodejs/app.js
@@ -33,7 +33,7 @@ bot.recognizer(recognizer);
 
 bot.dialog('SearchHotels', [
     (session, args, next) => {
-        session.send(`Welcome to the Hotels finder! We are analyzing your message: 'session.message.text'`);
+        session.send(`Welcome to the Hotels finder! We are analyzing your message: '${session.message.text}'`);
         // try extracting entities
         const cityEntity = builder.EntityRecognizer.findEntity(args.intent.entities, 'builtin.geography.city');
         const airportEntity = builder.EntityRecognizer.findEntity(args.intent.entities, 'AirportCode');


### PR DESCRIPTION
This commit fixes invalid string template of session message text returned as part of
the bot feedback. My error btw.

> We are analyzing your message: 'session.message.text'

> We are analyzing your message: 'Search hotels near LAX airport'

Thanks!